### PR TITLE
Fix infomation disclosure (ip leak)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
+  
   "dependencies": {
+    "uuid": "^8.3.2",
     "express": "^4.17.3",
     "localtunnel": "^2.0.2"
   }

--- a/protosync.js
+++ b/protosync.js
@@ -2,6 +2,7 @@ console.log('ProtoSYNC V2.0');
 
 const Express = require('express');
 const Tunnel = require('localtunnel');
+const { v4 } = require('uuid')
 var App = Express();
 App.use(Express.json());
 
@@ -17,7 +18,8 @@ var LoggedUsers = {};
 
 var ProtoTunnel = () => {
     Tunnel({
-        port: 4400
+        port: 4400,
+        subdomain: v4(), // Patch IP leak vuln
     }).then((tunnel) => {
         console.log('ProtoTUNNEL ready');
         URL = tunnel.url;


### PR DESCRIPTION
> oh god where do i start

Localtunnel has just changed their default subdomain to... include your IP.

This is well, not great, considering that all scripts are logged.

Please run a garbage script like this one, to clear your command logs.
Either reset your router or clear your logs. Run this 100 times to clear logs.
```lua
print('Real')
```
The commits below will patch this feature by setting subdomain to a v4 UUID. This not only doesn't leak your IP, but also makes it more difficult for people to find your tunnel.

Have a good day, yours truly, tech 😎 